### PR TITLE
Handle cases where one of the tumor/normal bams misses counts

### DIFF
--- a/neusomatic/python/generate_dataset.py
+++ b/neusomatic/python/generate_dataset.py
@@ -44,9 +44,14 @@ def get_variant_matrix_tabix(ref_file, count_bed, record, matrix_base_pad):
     logger = logging.getLogger(get_variant_matrix_tabix.__name__)
     chrom, pos, ref, alt = record[0:4]
     fasta_file = pysam.Fastafile(ref_file)
-    tb = pysam.TabixFile(count_bed, parser=pysam.asTuple())
-    tabix_records = tb.fetch(
-        chrom, pos - matrix_base_pad, pos + matrix_base_pad)
+    try:
+        tb = pysam.TabixFile(count_bed, parser=pysam.asTuple())
+        tabix_records = tb.fetch(
+            chrom, pos - matrix_base_pad, pos + matrix_base_pad)
+    except:
+        logger.warning("No count information at {}:{}-{} for {}".format(chrom,
+                     pos - matrix_base_pad, pos + matrix_base_pad, count_bed))
+        tabix_records = []
 
     NUC_to_NUM_tabix = {"A": 1, "C": 2, "G": 3, "T": 4, "-": 0}
     matrix_ = []


### PR DESCRIPTION
It will fix cases when one of the bams does not have reads in a region and thus count.bed.gz cannot find index for that region. 
With new fix we will use empty info for such regions.