### PR TITLE
fix a bug when a region pass the boundry of the ref

### DIFF
--- a/neusomatic/include/bam_variant.hpp
+++ b/neusomatic/include/bam_variant.hpp
@@ -142,11 +142,6 @@ std::vector<neusomatic::bio::Variant<std::string, Contig>> GetSNVs(const BamReco
 
   MDTags md(mdstr);
   std::pair<MDType, std::string> unit;
-  //std::cerr << mdstr << std::endl;
-  //while (md.Next(unit)) {
-    //std::cerr<<unit.first << ":" <<unit.second << std::endl;
-  //}
-
 
   std::vector<neusomatic::bio::Variant<std::string, Contig>> snvs_MDTags;
   int sum_M_len_before_D = 0;
@@ -202,7 +197,7 @@ std::vector<neusomatic::bio::Variant<std::string, Contig>> GetSNVs(const BamReco
   read_pos = bam.AlignmentPosition();
   auto b = cigar.begin();
   for (const auto& t : snvs_MDTags) {
-    int32_t ref_consume_goal = t.left() -  ref_pos; 
+    const int32_t ref_consume_goal = t.left() -  ref_pos;
     int32_t ref_consume = 0;
     int32_t read_consume = 0;
     while (ref_consume < ref_consume_goal) {

--- a/neusomatic/include/msa.hpp
+++ b/neusomatic/include/msa.hpp
@@ -44,8 +44,11 @@ class GappedSeq {
 public:
   GappedSeq(unsigned rlen): bases_(rlen), gaps_(rlen) {}
   
-  GappedSeq(const std::string& rseq, const GInv& ginv): bases_(rseq.begin(), rseq.end()), gaps_(rseq.length()), ginv_(ginv) {}
-
+  GappedSeq(const std::string& rseq, const GInv& ginv): bases_(rseq.begin(), rseq.end()), gaps_(rseq.length()), ginv_(ginv) {
+    if (rseq.size() + ginv.left()  != ginv.right()) {
+      throw std::runtime_error("seq length does not match the interval length");
+    }
+  }
   void SetGap(const size_t i, const int32_t pos, const int32_t len) {
     if (gaps_[i].IsNull()) {
       gaps_[i].Set(pos, len);
@@ -147,6 +150,7 @@ public:
     for (size_t i = refgap.left(); i < record_begin; ++i) {
       bases_[i - refgap.left()] = missing_chr_;
     }
+
     for (size_t i = record_end; i < refgap.right(); ++i) {
       bases_[i - refgap.left()] = missing_chr_;
     }


### PR DESCRIPTION
Truncate the region to the end of the reference if this happens.