### PR TITLE
Skipping multiprocess pool for single thread scenario

### DIFF
--- a/neusomatic/python/call.py
+++ b/neusomatic/python/call.py
@@ -350,19 +350,15 @@ def pred_vcf_records(ref_file, final_preds, chroms, num_threads):
         map_args.append([path, final_preds[path],
                          chroms, ref_file])
 
-    if num_threads == 1:
-        all_vcf_records = []
-        for w in map_args:
-            all_vcf_records.append(pred_vcf_records_path(w))
-    else:
-        pool = multiprocessing.Pool(num_threads)
         try:
-            all_vcf_records = pool.map_async(
-                pred_vcf_records_path, map_args).get()
-            pool.close()
+            if num_threads == 1:
+                all_vcf_records = [pred_vcf_records_path(w) for w in map_args]
+            else:
+                with multiprocessing.Pool(num_threads) as pool:
+                    all_vcf_records = pool.map_async(
+                        pred_vcf_records_path, map_args).get()
         except Exception as inst:
             logger.error(inst)
-            pool.close()
             traceback.print_exc()
             raise Exception
 
@@ -786,13 +782,14 @@ def call_neusomatic(candidates_tsv, ref_file, out_dir, checkpoint, num_threads,
                 current_L = 0
                 candidate_files = []
 
-        pool = multiprocessing.Pool(num_threads)
         try:
-            all_records = pool.map_async(single_thread_call, map_args).get()
-            pool.close()
+            if num_threads == 1:
+                all_records = [single_thread_call(w) for w in map_args]
+            else:
+                with multiprocessing.Pool(num_threads) as pool:
+                    all_records = pool.map_async(single_thread_call, map_args).get()
         except Exception as inst:
             logger.error(inst)
-            pool.close()
             traceback.print_exc()
             raise Exception
 

--- a/neusomatic/python/dataloader.py
+++ b/neusomatic/python/dataloader.py
@@ -203,24 +203,17 @@ class NeuSomaticDataset(torch.utils.data.Dataset):
                                  max_load_, nclasses_t, nclasses_l, self.matrix_dtype])
                 Ls_.append(self.Ls[i_b])
             logger.info("Len's of tsv files in this batch: {}".format(Ls_))
-            if len(map_args) == 1:
-                records_ = [extract_info_tsv(map_args[0])]
-            else:
+            try:
                 if num_threads == 1:
-                    records_ = []
-                    for w in map_args:
-                        records_.append(extract_info_tsv(w))
+                    records_ = [extract_info_tsv(w) for w in map_args]
                 else:
-                    pool = multiprocessing.Pool(num_threads)
-                    try:
+                    with multiprocessing.Pool(num_threads) as pool:
                         records_ = pool.map_async(
                             extract_info_tsv, map_args).get()
-                        pool.close()
-                    except Exception as inst:
-                        pool.close()
-                        logger.error(inst)
-                        traceback.print_exc()
-                        raise Exception
+            except Exception as inst:
+                logger.error(inst)
+                traceback.print_exc()
+                raise Exception
 
             for o in records_:
                 if o is None:

--- a/neusomatic/python/generate_dataset.py
+++ b/neusomatic/python/generate_dataset.py
@@ -2103,13 +2103,11 @@ def generate_dataset(work, truth_vcf_file, mode,  tumor_pred_vcf_file, region_be
         for w in map_args:
             records_data.append(find_records(w))
     else:
-        pool = multiprocessing.Pool(num_threads)
         try:
-            records_data = pool.map_async(find_records, map_args).get()
-            pool.close()
+            with multiprocessing.Pool(num_threads) as pool:
+                records_data = pool.map_async(find_records, map_args).get()
         except Exception as inst:
             logger.error(inst)
-            pool.close()
             traceback.print_exc()
             raise Exception
     for o in records_data:
@@ -2184,16 +2182,14 @@ def generate_dataset(work, truth_vcf_file, mode,  tumor_pred_vcf_file, region_be
                 if num_threads == 1:
                     records_done_ = [parallel_generation([map_args_records, matrix_base_pad, chrom_lengths, tumor_count_bed, normal_count_bed])]
                 else: 
-                    pool = multiprocessing.Pool(num_threads)
                     try:
                         split_len=max(1,len_records//num_threads)
-                        records_done_ = pool.map_async(
-                            parallel_generation, [[map_args_records[i_split:i_split+(split_len)],matrix_base_pad, chrom_lengths, tumor_count_bed, normal_count_bed] 
-                            for   i_split in range(0, len_records, split_len)]).get()
-                        pool.close()
+                        with multiprocessing.Pool(num_threads) as pool:
+                            records_done_ = pool.map_async(
+                                parallel_generation, [[map_args_records[i_split:i_split+(split_len)],matrix_base_pad, chrom_lengths, tumor_count_bed, normal_count_bed] 
+                                for   i_split in range(0, len_records, split_len)]).get()
                     except Exception as inst:
                         logger.error(inst)
-                        pool.close()
                         traceback.print_exc()
                         raise Exception
 

--- a/neusomatic/python/resolve_variants.py
+++ b/neusomatic/python/resolve_variants.py
@@ -478,16 +478,14 @@ def resolve_variants(input_bam, resolved_vcf, reference, target_vcf_file,
             out_variants_list = []
             i = 0
             while i < len(map_args):
-                pool = multiprocessing.Pool(num_threads)
                 batch_i_s = i
                 batch_i_e = min(i + n_per_bacth, len(map_args))
-                out_variants_list.extend(pool.map_async(
-                    find_resolved_variants, map_args[batch_i_s:batch_i_e]).get())
+                with multiprocessing.Pool(num_threads) as pool:
+                    out_variants_list.extend(pool.map_async(
+                        find_resolved_variants, map_args[batch_i_s:batch_i_e]).get())
                 i = batch_i_e
-                pool.close()
         except Exception as inst:
             logger.error(inst)
-            pool.close()
             traceback.print_exc()
             raise Exception
     else:

--- a/neusomatic/python/scan_alignments.py
+++ b/neusomatic/python/scan_alignments.py
@@ -198,12 +198,13 @@ def scan_alignments(work, merge_d_for_scan, scan_alignments_binary, input_bam,
                                   i), "count.bed.gz"),
                               os.path.join(work, "work.{}".format(i), "region.bed")]
 
-    pool = multiprocessing.Pool(num_threads)
     try:
-        outputs = pool.map_async(run_scan_alignments, map_args).get()
-        pool.close()
+        if num_threads == 1:
+            outputs = [run_scan_alignments(w) for w in map_args]
+        else:
+            with multiprocessing.Pool(num_threads) as pool:
+                outputs = pool.map_async(run_scan_alignments, map_args).get()
     except Exception as inst:
-        pool.close()
         logger.error(inst)
         traceback.print_exc()
         raise Exception


### PR DESCRIPTION
If the number of threads is 1, additional threads/processes will not be spawned by avoiding use of multiprocessing pool.